### PR TITLE
feat: Integrate Facebook Audience Network API with Flask

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-global activities web platform
+# Global Activities Web Platform - Facebook API Integration
+
+This project is a simple Flask web application that demonstrates how to integrate with the Facebook Marketing API, including the Audience Network.
+
+## Getting Started
+
+### 1. Prerequisites
+
+- Python 3.6+
+- A Facebook Developer account
+- An App ID, App Secret, and Access Token from your Facebook App.
+
+### 2. Installation
+
+Clone the repository and install the dependencies:
+
+```bash
+git clone <repository_url>
+cd <repository_name>
+pip install -r requirements.txt
+```
+
+### 3. Configuration
+
+Open the `app.py` file and replace the placeholder values for `APP_ID`, `APP_SECRET`, and `ACCESS_TOKEN` with your actual credentials from the Facebook Developer portal.
+
+```python
+# --- Facebook SDK Initialization ---
+# PLEASE REPLACE WITH YOUR OWN CREDENTIALS
+APP_ID = 'YOUR_APP_ID'
+APP_SECRET = 'YOUR_APP_SECRET'
+ACCESS_TOKEN = 'YOUR_ACCESS_TOKEN'
+```
+
+### 4. Running the Application
+
+To start the Flask development server, run the following command:
+
+```bash
+python app.py
+```
+
+The application will be available at `http://localhost:8080`.
+
+### 5. API Endpoints
+
+- **`GET /`**: The main landing page.
+- **`GET /audience_network_adsets`**: Retrieves a list of ad sets from your ad account that are specifically targeted to run on the Facebook Audience Network. This demonstrates how to use the Marketing API to query for Audience Network-related assets.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,47 @@
+from flask import Flask, render_template, jsonify
+from facebook_business.api import FacebookAdsApi
+from facebook_business.adobjects.adaccount import AdAccount
+
+app = Flask(__name__)
+
+# --- Facebook SDK Initialization ---
+# PLEASE REPLACE WITH YOUR OWN CREDENTIALS
+APP_ID = 'YOUR_APP_ID'
+APP_SECRET = 'YOUR_APP_SECRET'
+ACCESS_TOKEN = 'YOUR_ACCESS_TOKEN'
+
+FacebookAdsApi.init(APP_ID, APP_SECRET, ACCESS_TOKEN)
+
+@app.route('/')
+def home():
+    return render_template('index.html')
+
+@app.route('/audience_network_adsets')
+def get_audience_network_adsets():
+    try:
+        fields = [
+            'name',
+            'targeting',
+        ]
+        ad_account = AdAccount('me')
+        adsets = ad_account.get_ad_sets(fields=fields)
+
+        # Filter for ad sets that target the Audience Network
+        audience_network_adsets = []
+        for adset in adsets:
+            targeting = adset.get('targeting', {})
+            publisher_platforms = targeting.get('publisher_platforms', [])
+            if 'audience_network' in publisher_platforms:
+                audience_network_adsets.append({
+                    'name': adset['name'],
+                    'id': adset['id'],
+                    'targeting': targeting,
+                })
+
+        return jsonify(audience_network_adsets)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+
+if __name__ == '__main__':
+    app.run(debug=True, port=8080)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+facebook_business

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Facebook API Integration</title>
+</head>
+<body>
+    <h1>Hello, World!</h1>
+    <p>This is the initial landing page.</p>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a new Flask application that demonstrates how to integrate with the Facebook Audience Network API.

The application includes:
- A basic Flask server setup (`app.py`).
- The `facebook-business` SDK dependency (`requirements.txt`).
- An example API endpoint (`/audience_network_adsets`) that fetches ad sets specifically targeted to the Audience Network.
- A detailed `README.md` with setup and usage instructions.

This provides a clear and functional example for developers looking to interact with the Audience Network programmatically via the Facebook Marketing API.

## Summary by Sourcery

Introduce a sample Flask-based web application that connects to the Facebook Marketing API to fetch Audience Network ad sets and includes setup documentation

New Features:
- Add Flask application integrating with Facebook Ads SDK to demonstrate Audience Network integration
- Implement /audience_network_adsets endpoint to retrieve and filter ad sets targeting the Audience Network
- Include basic landing page template as placeholder for future UI

Documentation:
- Provide detailed README with installation, configuration, and usage instructions